### PR TITLE
Make Postgres connection string changeable after instantiation

### DIFF
--- a/build/version.props
+++ b/build/version.props
@@ -3,7 +3,7 @@
 		<VersionMajor>6</VersionMajor>
 		<VersionMinor>1</VersionMinor>
 		<VersionPatch>1</VersionPatch>
-		<VersionQuality>100</VersionQuality>
+		<VersionQuality>102</VersionQuality>
 		<VersionPrefix>$(VersionMajor).$(VersionMinor).$(VersionPatch).$(VersionQuality)</VersionPrefix>
 	</PropertyGroup>
 </Project>

--- a/src/DotNetCore.CAP.PostgreSql/CAP.Options.Extensions.cs
+++ b/src/DotNetCore.CAP.PostgreSql/CAP.Options.Extensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using DotNetCore.CAP;
+using DotNetCore.CAP.PostgreSql;
 using Microsoft.EntityFrameworkCore;
 
 // ReSharper disable once CheckNamespace
@@ -20,6 +21,7 @@ namespace Microsoft.Extensions.DependencyInjection
             if (configure == null) throw new ArgumentNullException(nameof(configure));
 
             configure += x => x.Version = options.Version;
+            configure += x => PostgreSqlConnectionDataManager.ConnectionString = x.ConnectionString;
 
             options.RegisterExtension(new PostgreSqlCapOptionsExtension(configure));
 

--- a/src/DotNetCore.CAP.PostgreSql/IDataStorage.PostgreSql.cs
+++ b/src/DotNetCore.CAP.PostgreSql/IDataStorage.PostgreSql.cs
@@ -75,7 +75,7 @@ namespace DotNetCore.CAP.PostgreSql
 
             if (dbTransaction == null)
             {
-                using var connection = new NpgsqlConnection(_options.Value.ConnectionString);
+                using var connection = new NpgsqlConnection(PostgreSqlConnectionDataManager.ConnectionString);
                 connection.ExecuteNonQuery(sql, sqlParams: sqlParams);
             }
             else
@@ -138,7 +138,7 @@ namespace DotNetCore.CAP.PostgreSql
         public async Task<int> DeleteExpiresAsync(string table, DateTime timeout, int batchCount = 1000,
             CancellationToken token = default)
         {
-            await using var connection = new NpgsqlConnection(_options.Value.ConnectionString);
+            await using var connection = new NpgsqlConnection(PostgreSqlConnectionDataManager.ConnectionString);
             return connection.ExecuteNonQuery(
                 $"DELETE FROM {table} WHERE \"Id\" IN (SELECT \"Id\" FROM {table} WHERE \"ExpiresAt\" < @timeout LIMIT @batchCount);", null,
                 new NpgsqlParameter("@timeout", timeout), new NpgsqlParameter("@batchCount", batchCount));
@@ -152,7 +152,7 @@ namespace DotNetCore.CAP.PostgreSql
 
         public IMonitoringApi GetMonitoringApi()
         {
-            return new PostgreSqlMonitoringApi(_options, _initializer);
+            return new PostgreSqlMonitoringApi(_initializer);
         }
 
         private async Task ChangeMessageStateAsync(string tableName, MediumMessage message, StatusName state)
@@ -169,7 +169,7 @@ namespace DotNetCore.CAP.PostgreSql
                 new NpgsqlParameter("@StatusName", state.ToString("G"))
             };
 
-            await using var connection = new NpgsqlConnection(_options.Value.ConnectionString);
+            await using var connection = new NpgsqlConnection(PostgreSqlConnectionDataManager.ConnectionString);
             connection.ExecuteNonQuery(sql, sqlParams: sqlParams);
         }
 
@@ -179,7 +179,7 @@ namespace DotNetCore.CAP.PostgreSql
                 $"INSERT INTO {_recName}(\"Id\",\"Version\",\"Name\",\"Group\",\"Content\",\"Retries\",\"Added\",\"ExpiresAt\",\"StatusName\")" +
                 $"VALUES(@Id,'{_capOptions.Value.Version}',@Name,@Group,@Content,@Retries,@Added,@ExpiresAt,@StatusName) RETURNING \"Id\";";
 
-            using var connection = new NpgsqlConnection(_options.Value.ConnectionString);
+            using var connection = new NpgsqlConnection(PostgreSqlConnectionDataManager.ConnectionString);
             connection.ExecuteNonQuery(sql, sqlParams: sqlParams);
         }
 
@@ -197,7 +197,7 @@ namespace DotNetCore.CAP.PostgreSql
                 new NpgsqlParameter("@Added", fourMinAgo)
             };
 
-            await using var connection = new NpgsqlConnection(_options.Value.ConnectionString);
+            await using var connection = new NpgsqlConnection(PostgreSqlConnectionDataManager.ConnectionString);
             var result = connection.ExecuteReader(sql, reader =>
             {
                 var messages = new List<MediumMessage>();

--- a/src/DotNetCore.CAP.PostgreSql/IStorageInitializer.PostgreSql.cs
+++ b/src/DotNetCore.CAP.PostgreSql/IStorageInitializer.PostgreSql.cs
@@ -38,7 +38,7 @@ namespace DotNetCore.CAP.PostgreSql
             if (cancellationToken.IsCancellationRequested) return;
 
             var sql = CreateDbTablesScript(_options.Value.Schema);
-            await using (var connection = new NpgsqlConnection(_options.Value.ConnectionString))
+            await using (var connection = new NpgsqlConnection(PostgreSqlConnectionDataManager.ConnectionString))
                 connection.ExecuteNonQuery(sql);
 
             _logger.LogDebug("Ensuring all create database tables script are applied.");

--- a/src/DotNetCore.CAP.PostgreSql/PostgreSqlConnectionDataManager.cs
+++ b/src/DotNetCore.CAP.PostgreSql/PostgreSqlConnectionDataManager.cs
@@ -1,0 +1,7 @@
+﻿namespace DotNetCore.CAP.PostgreSql
+{
+    public static class PostgreSqlConnectionDataManager
+    {
+        public static string ConnectionString { get; set; } = "";
+    }
+}


### PR DESCRIPTION
Currently, the only time the db connection string can be set is when first setting up CAP (AddCap in startup) - this PR makes it so the connection string is stored on a static class and can be changed by consumers (so, for instance, if the user's password is programmatically updated, CAP can be updated to use the new password too, without having to restart the consuming application).

I've only coded it for Postgres, cause that's the only db type Spotlight uses as CAP storage, but in theory the same thing would work for the other DB flavoured projects too.